### PR TITLE
Add link to Ruby implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Ports in other languages
 - **Go:** [n2p5/uuid47](https://github.com/n2p5/uuid47) — Go port of UUIDv47
 - **JavaScript:** [sh1kxrv/node_uuidv47](https://github.com/sh1kxrv/node_uuidv47) — JavaScript port of UUIDv47 with native bindings
 - **C#/.NET:** [taiseiue/UUIDv47Sharp](https://github.com/taiseiue/UUIDv47Sharp) - C#/.NET ecosystem port of UUIDv47
+- **Ruby:** [sylph01/uuid47](https://github.com/sylph01/uuid47) - Ruby port of UUIDv47
 
 ------------------------------------------------------------------
 


### PR DESCRIPTION
Hi! I made a quick implementation of UUIDv47 in Ruby and added it under the "Ports in other languages" section.