### PR TITLE
Add implications of duplicate randoms section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ The mask is XOR with a keyed PRF → perfectly invertible when the key is known.
 ### Collision analysis
 Mapping is injective; collisions reduce to duplicate randoms within the same ms.
 
+### Implications of Duplicate Randoms for Differing Timestamps
+If two IDs have the same randoms, but different timestamps, then XORing the facade IDs will reveal the XOR of the timestamps, because the mask will cancel out. This does not reveal the key, only an upper bound on the duration between when the IDs were generated. For a 1% chance of finding 2 matching randoms, using the birthday problem approximation, ~20 billion IDs would need to be generated, or ~60 billion for a 10% chance. For an attacker trying to reveal information about a chosen target ID, they would need to generate on average 2^74 IDs, which is infeasible.
+
 ------------------------------------------------------------------
 
 Security model


### PR DESCRIPTION
Added a note on what happens when there is a duplicate random. It's low risk and low impact, but might be worth mentioning since it's technically feasible due to birthday problem probabilities.

Eg:
If someone saw facade ids `3309401a-ae5f-4032-8c96-fd3b3405593e` and `3309401a-fb28-4032-8c96-fd3b3405593e`, and noted the randoms are the same, they could XOR them to get `00000000-5577-0000-0000-000000000000`.  This tells us the upper bound on the difference of the timestamps is `0x5577`, or 21879 ms.

The lower bound is a bit trickier, but I think it's the smallest non-zero subset-sum you can make by splitting the set bits of the XOR into two groups. Which in this case is 10889 ms.

The real uuidv7s were `01997155-1e00-7032-8c96-fd3b3405593e` and `01997155-4b77-7032-8c96-fd3b3405593e`, so the real difference was 11639 ms. The key was `0011223344556677:8899aabbccddeeff`.